### PR TITLE
git: 改行衝突を減らす .gitattributes を追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Keep line endings stable across platforms without forcing mass conversion.
+* text=auto
+
+# Binary assets
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.bmp binary
+*.ico binary
+*.wav binary
+*.mp3 binary
+*.ogg binary
+*.flac binary
+*.zip binary
+*.7z binary
+*.rar binary
+*.gz binary
+*.bz2 binary
+*.xz binary
+*.pdf binary
+*.rom binary
+*.d88 binary
+*.n80 binary


### PR DESCRIPTION
概要
改行由来の不要コンフリクトを減らすため、リポジトリに .gitattributes を追加します。

変更内容
- * text=auto を設定
- バイナリ拡張子を binary として明示（画像/音声/圧縮/ROM/D88 など）

意図
- 既存ファイルの大規模改行変換を避けつつ、今後の改行起因コンフリクトを減らすための最小構成です。