### PR TITLE
i8251: Linuxビルドエラー（uint8_t未定義）を修正

### DIFF
--- a/Source/ePC-8801MA/vm/i8251.cpp
+++ b/Source/ePC-8801MA/vm/i8251.cpp
@@ -191,7 +191,7 @@ void I8251::event_callback(int event_id, int err)
 					status |= SYNDET;
 					write_signals(&outputs_syndet, 0xffffffff);
 				} else {
-					recv = (uint8_t)val;
+					recv = (uint8)val;
 					status |= RXRDY;
 					write_signals(&outputs_rxrdy, 0xffffffff);
 				}
@@ -205,7 +205,7 @@ void I8251::event_callback(int event_id, int err)
 		}
 	} else if(event_id == EVENT_SEND) {
 		if(txen && !send_buffer->empty()) {
-			uint8_t send = send_buffer->read();
+			uint8 send = send_buffer->read();
 			if(loopback) {
 				// send to this device
 				write_signal(SIG_I8251_RECV, send, 0xff);


### PR DESCRIPTION
概要
Linuxビルドで i8251.cpp の uint8_t が未定義扱いとなり、send 変数も連鎖的に解決できずコンパイル失敗していたため修正しました。

変更内容
- Source/ePC-8801MA/vm/i8251.cpp
  - recv 代入のキャスト: (uint8_t) -> (uint8)
  - 送信バッファ変数型: uint8_t -> uint8

補足
- プロジェクトで既に使っている独自型 uint8 に統一する最小修正です。
- macOSローカルビルドは成功（warningのみ）。