### PR TITLE
4MHzでWizardry起動を安定化（FDCタイミング調整）

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,28 +2,55 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "(lldb) Launch macOS",
-            "type": "cppdbg",
+            "name": "macOS: 通常起動 (lldb extension)",
+            "type": "lldb",
             "request": "launch",
             "program": "${workspaceFolder}/build/XM8.app/Contents/MacOS/xm8",
             "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [],
-            "externalConsole": true,
-            "MIMode": "lldb"
+            "cwd": "${workspaceFolder}"
         },
         {
-            "name": "(gdb) Launch Linux",
+            "name": "Linux: 通常起動 (gdb)",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/xm8",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
-            "environment": [],
             "externalConsole": false,
             "MIMode": "gdb"
+        },
+        {
+            "name": "macOS: Wizardry 安定化 (LOST=15000 + CONST_EXEC=1)",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/XM8.app/Contents/MacOS/xm8",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "XM8_FDC_TRACE_MAX_LINES": "400000",
+                "XM8_FDC_SEEK_SCALE": "1000",
+                "XM8_DISABLE_UNSTABLE_MASK": "1",
+                "XM8_FDC_LOST_USEC": "15000",
+                "XM8_FDC_CONST_EXEC_USEC": "1",
+                "XM8_FDC_TRACE_FILE": "xm8_fdc_trace_wiz_stable.log"
+            }
+        },
+        {
+            "name": "macOS: FDCトレース基準 (scale=1000, no-unstable)",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/XM8.app/Contents/MacOS/xm8",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "XM8_FDC_TRACE": "1",
+                "XM8_FDC_TRACE_IO": "1",
+                "XM8_FDC_TRACE_MAX_LINES": "400000",
+                "XM8_FDC_SEEK_SCALE": "1000",
+                "XM8_DISABLE_UNSTABLE_MASK": "1",
+                "XM8_FDC_TRACE_FILE": "xm8_fdc_trace_s1000_nounstable.log"
+            }
         }
     ]
 }

--- a/Source/ePC-8801MA/vm/disk.cpp
+++ b/Source/ePC-8801MA/vm/disk.cpp
@@ -8,6 +8,7 @@
 */
 
 #include "disk.h"
+#include <cstdlib>
 
 // crc table
 static const uint16 crc_table[256] = {
@@ -71,6 +72,18 @@ static const int secsize[8] = {
 };
 
 static uint8 tmp_buffer[DISK_BUFFER_SIZE];
+static bool g_disable_unstable_checked = false;
+static bool g_disable_unstable = false;
+
+static bool disable_unstable_mask()
+{
+	if(!g_disable_unstable_checked) {
+		const char* env = getenv("XM8_DISABLE_UNSTABLE_MASK");
+		g_disable_unstable = (env != NULL && env[0] != '\0' && env[0] != '0');
+		g_disable_unstable_checked = true;
+	}
+	return g_disable_unstable;
+}
 
 typedef struct {
 	int type;
@@ -567,16 +580,9 @@ bool DISK::get_track(int trk, int side)
 
 bool DISK::make_track(int trk, int side)
 {
-	if(media_type == MEDIA_TYPE_2D && drive_type == DRIVE_TYPE_2DD) {
-		if(trk >= 0) {
-			if(trk & 1) {
-				return false;
-			}
-			trk >>= 1;
-		}
-	} else if(media_type == MEDIA_TYPE_2DD && drive_type == DRIVE_TYPE_2D) {
-		if(trk >= 0) trk <<= 1;
-	}
+	// get_track() already applies 2D/2DD logical<->physical track conversion.
+	// Converting here as well causes a double-conversion mismatch between
+	// make_track() generated data positions and get_sector() lookups.
 	int track_size = get_track_size();
 	
 	if(!get_track(trk, side)) {
@@ -658,10 +664,10 @@ bool DISK::make_track(int trk, int side)
 			if(p < track_size) track[p++] = am2;
 			crc = (uint16)((crc << 8) ^ crc_table[(uint8)(crc >> 8) ^ am2]);
 			// data
-			uint8* u = get_unstable_sector(sector, i);
+			uint8* u = get_unstable_sector(sector, i, t[0], t[1], t[2], t[3], data_size.sd);
 			for(int j = 0; j < data_size.sd; j++) {
 				if(p < track_size) {
-					uint8 mask = u ? u[j] : 0;
+					uint8 mask = (u != NULL && !disable_unstable_mask()) ? u[j] : 0;
 					track[p++] = (t[0x10 + j] & ~mask) | (rand() & mask);
 				}
 				crc = (uint16)((crc << 8) ^ crc_table[(uint8)(crc >> 8) ^ t[0x10 + j]]);
@@ -719,7 +725,6 @@ bool DISK::get_sector(int trk, int side, int index)
 	if(index >= sector_num.sd) {
 		return false;
 	}
-	unstable = get_unstable_sector(t, index);
 	
 	// skip sector
 	for(int i = 0; i < index; i++) {
@@ -727,6 +732,9 @@ bool DISK::get_sector(int trk, int side, int index)
 		data_size.read_2bytes_le_from(t + 14);
 		t += data_size.sd + 0x10;
 	}
+	pair target_size;
+	target_size.read_2bytes_le_from(t + 14);
+	unstable = get_unstable_sector(buffer + offset.d, index, t[0], t[1], t[2], t[3], target_size.sd);
 	set_sector_info(t);
 	return true;
 }
@@ -764,29 +772,57 @@ int DISK::get_track_num(uint8* t)
 	return result;
 }
 
-uint8* DISK::get_unstable_sector(uint8* t, int index)
+uint8* DISK::get_unstable_sector(uint8* t, int index, uint8 c, uint8 h, uint8 r, uint8 n, int size)
 {
 	int track = get_track_num(t);
 	if(track < 0) {
 		return NULL;
 	}
+	uint8* end = buffer + sizeof(buffer);
 	pair offset, num, idx, data_size;
 	offset.read_4bytes_le_from(buffer + 0x20 + track * 4);
 	t = buffer + offset.d;
+	if(t < buffer || t + 0x10 > end) {
+		return NULL;
+	}
 	num.read_2bytes_le_from(t + 4);
+	if(num.sd <= 0 || num.sd > 256) {
+		return NULL;
+	}
 	
 	for(int i = 0; i < num.sd; i++) {
+		if(t + 0x10 > end) {
+			return NULL;
+		}
 		data_size.read_2bytes_le_from(t + 14);
+		if(data_size.sd < 0 || data_size.sd > 16384 || t + data_size.sd + 0x10 > end) {
+			return NULL;
+		}
 		t += data_size.sd + 0x10;
 	}
 	if(track == get_track_num(t)) {
+		if(t < buffer || t + 0x10 > end) {
+			return NULL;
+		}
 		num.read_2bytes_le_from(t + 4);
+		if(num.sd <= 0 || num.sd > 256) {
+			return NULL;
+		}
 		for(int i = 0; i < num.sd; i++) {
-			idx.read_2bytes_le_from(t + 9);
-			if(idx.sd == index) {
-				return t + 0x10;
+			if(t + 0x10 > end) {
+				return NULL;
 			}
+			idx.read_2bytes_le_from(t + 9);
 			data_size.read_2bytes_le_from(t + 14);
+			if(data_size.sd < 0 || data_size.sd > 16384 || t + data_size.sd + 0x10 > end) {
+				return NULL;
+			}
+			if(idx.sd == index) {
+				if(t[0] == c && t[1] == h && t[2] == r && t[3] == n && data_size.sd == size) {
+					return t + 0x10;
+				}
+				return NULL;
+			}
 			t += data_size.sd + 0x10;
 		}
 	}

--- a/Source/ePC-8801MA/vm/disk.h
+++ b/Source/ePC-8801MA/vm/disk.h
@@ -61,7 +61,7 @@ private:
 	bool temporary;
 	uint8 fdi_header[4096];
 	int get_track_num(uint8* t);
-	uint8* get_unstable_sector(uint8* t, int index);
+	uint8* get_unstable_sector(uint8* t, int index, uint8 c, uint8 h, uint8 r, uint8 n, int size);
 	
 	void set_sector_info(uint8 *t);
 	void trim_buffer();

--- a/Source/ePC-8801MA/vm/event.cpp
+++ b/Source/ePC-8801MA/vm/event.cpp
@@ -249,11 +249,11 @@ void EVENT::drive()
 			if (main_cpu_exec > 0) {
 				// single execution ?
 				if (single_exec == true) {
-					if (main_cpu_exec > 4) {
-						main_cpu_exec = 4;
+						if (main_cpu_exec > 4) {
+							main_cpu_exec = 4;
+						}
 					}
-				}
-				cpu_done = d_cpu[0].device->run(main_cpu_exec);
+					cpu_done = d_cpu[0].device->run(main_cpu_exec);
 			}
 
 			// if registered new event during main cpu execution, recalc min_event_clock
@@ -268,10 +268,10 @@ void EVENT::drive()
 				if (cpu_remain > 0) {
 					sub_cpu_exec = cpu_remain;
 					if (single_exec == true) {
-						if (sub_cpu_exec > 4) {
-							sub_cpu_exec = 4;
+							if (sub_cpu_exec > 4) {
+								sub_cpu_exec = 4;
+							}
 						}
-					}
 
 					sub_cpu_done = d_cpu[1].device->run(sub_cpu_exec);
 					cpu_remain -= sub_cpu_done;
@@ -282,10 +282,10 @@ void EVENT::drive()
 				if (cpu_remain > 2) {
 					sub_cpu_exec = cpu_remain / 2;
 					if (single_exec == true) {
-						if (sub_cpu_exec > 4) {
-							sub_cpu_exec = 4;
+							if (sub_cpu_exec > 4) {
+								sub_cpu_exec = 4;
+							}
 						}
-					}
 					
 					sub_cpu_done = d_cpu[1].device->run(sub_cpu_exec);
 					cpu_remain -= (sub_cpu_done * 2);

--- a/Source/ePC-8801MA/vm/upd765a.cpp
+++ b/Source/ePC-8801MA/vm/upd765a.cpp
@@ -77,17 +77,130 @@
 static FILE* g_fdc_trace_file = NULL;
 static bool g_fdc_trace_checked = false;
 static int g_fdc_trace_lines = 0;
+static int g_fdc_trace_max_lines = 200000;
+static bool g_fdc_trace_io_checked = false;
+static bool g_fdc_trace_io = false;
+static bool g_fdc_seek_scale_checked = false;
+static int g_fdc_seek_scale = 1000;
+static bool g_fdc_disable_unstable_checked = false;
+static bool g_fdc_disable_unstable = true;
+static bool g_fdc_const_exec_checked = false;
+static bool g_fdc_const_exec = true;
+static bool g_fdc_request_single_exec_checked = false;
+static bool g_fdc_request_single_exec = true;
+static bool g_fdc_tc_exec_checked = false;
+static bool g_fdc_tc_exec = true;
+static bool g_fdc_lost_usec_checked = false;
+static int g_fdc_lost_usec = 15000;
 
 static bool fdc_trace_enabled()
 {
 	if(!g_fdc_trace_checked) {
 		const char* env = getenv("XM8_FDC_TRACE");
 		if(env != NULL && env[0] != '\0' && env[0] != '0') {
-			g_fdc_trace_file = fopen("xm8_fdc_trace.log", "w");
+			const char* trace_path = getenv("XM8_FDC_TRACE_FILE");
+			if(trace_path != NULL && trace_path[0] != '\0') {
+				g_fdc_trace_file = fopen(trace_path, "w");
+			} else {
+				g_fdc_trace_file = fopen("xm8_fdc_trace.log", "w");
+			}
+		}
+		const char* max_lines = getenv("XM8_FDC_TRACE_MAX_LINES");
+		if(max_lines != NULL && max_lines[0] != '\0') {
+			long v = strtol(max_lines, NULL, 10);
+			if(v > 0 && v <= 2000000) {
+				g_fdc_trace_max_lines = (int)v;
+			}
 		}
 		g_fdc_trace_checked = true;
 	}
 	return g_fdc_trace_file != NULL;
+}
+
+static bool fdc_trace_io_enabled()
+{
+	if(!g_fdc_trace_io_checked) {
+		const char* env = getenv("XM8_FDC_TRACE_IO");
+		g_fdc_trace_io = (env != NULL && env[0] != '\0' && env[0] != '0');
+		g_fdc_trace_io_checked = true;
+	}
+	return g_fdc_trace_io;
+}
+
+static int fdc_seek_scale()
+{
+	if(!g_fdc_seek_scale_checked) {
+		const char* env = getenv("XM8_FDC_SEEK_SCALE");
+		if(env != NULL && env[0] != '\0') {
+			long v = strtol(env, NULL, 10);
+			if(v >= 1 && v <= 10000) {
+				g_fdc_seek_scale = (int)v;
+			}
+		}
+		g_fdc_seek_scale_checked = true;
+	}
+	return g_fdc_seek_scale;
+}
+
+static bool fdc_disable_unstable_mask()
+{
+	if(!g_fdc_disable_unstable_checked) {
+		const char* env = getenv("XM8_DISABLE_UNSTABLE_MASK");
+		g_fdc_disable_unstable = (env != NULL && env[0] != '\0' && env[0] != '0');
+		g_fdc_disable_unstable_checked = true;
+	}
+	return g_fdc_disable_unstable;
+}
+
+static bool fdc_const_exec_timing()
+{
+	if(!g_fdc_const_exec_checked) {
+		const char* env = getenv("XM8_FDC_CONST_EXEC_USEC");
+		g_fdc_const_exec = (env != NULL && env[0] != '\0' && env[0] != '0');
+		g_fdc_const_exec_checked = true;
+	}
+	return g_fdc_const_exec;
+}
+
+static bool fdc_request_single_exec_enabled()
+{
+	if(!g_fdc_request_single_exec_checked) {
+		const char* env = getenv("XM8_FDC_REQUEST_SINGLE_EXEC");
+		if(env != NULL && env[0] != '\0') {
+			g_fdc_request_single_exec = (env[0] != '0');
+		}
+		g_fdc_request_single_exec_checked = true;
+	}
+	return g_fdc_request_single_exec;
+}
+
+static bool fdc_tc_exec_enabled()
+{
+	if(!g_fdc_tc_exec_checked) {
+		const char* env = getenv("XM8_FDC_TC_EXEC");
+		if(env != NULL && env[0] != '\0') {
+			g_fdc_tc_exec = (env[0] != '0');
+		}
+		g_fdc_tc_exec_checked = true;
+	}
+	return g_fdc_tc_exec;
+}
+
+static int fdc_lost_event_usec()
+{
+	if(!g_fdc_lost_usec_checked) {
+		const char* env = getenv("XM8_FDC_LOST_USEC");
+		if(env != NULL && env[0] != '\0') {
+			long v = strtol(env, NULL, 10);
+			if(v >= 1 && v <= 10000000) {
+				g_fdc_lost_usec = (int)v;
+			} else if(v <= 0) {
+				g_fdc_lost_usec = 0;
+			}
+		}
+		g_fdc_lost_usec_checked = true;
+	}
+	return g_fdc_lost_usec;
 }
 
 static void fdc_trace(const char* fmt, ...)
@@ -95,7 +208,7 @@ static void fdc_trace(const char* fmt, ...)
 	if(!fdc_trace_enabled()) {
 		return;
 	}
-	if(g_fdc_trace_lines > 20000) {
+	if(g_fdc_trace_lines > g_fdc_trace_max_lines) {
 		return;
 	}
 	va_list ap;
@@ -105,6 +218,17 @@ static void fdc_trace(const char* fmt, ...)
 	fputc('\n', g_fdc_trace_file);
 	fflush(g_fdc_trace_file);
 	g_fdc_trace_lines++;
+}
+
+static uint32 fdc_hash_bytes(const uint8* data, int len)
+{
+	// FNV-1a 32-bit for lightweight sector content tracing.
+	uint32 hash = 2166136261u;
+	for(int i = 0; i < len; i++) {
+		hash ^= data[i];
+		hash *= 16777619u;
+	}
+	return hash;
 }
 
 #define REGISTER_PHASE_EVENT(phs, usec) { \
@@ -227,6 +351,13 @@ void UPD765A::initialize()
 	phase = prevphase = PHASE_IDLE;
 	status = S_RQM;
 	seekstat = 0;
+	command = 0;
+	result = 0;
+	hdue = 0;
+	id[0] = id[1] = id[2] = id[3] = 0;
+	eot = 0;
+	gpl = 0;
+	dtl = 0;
 	bufptr = buffer; // temporary
 	phase_id = drq_id = lost_id = result7_id = -1;
 	seek_id[0] = seek_id[1] = seek_id[2] = seek_id[3] = -1;
@@ -269,23 +400,69 @@ void UPD765A::release()
 		g_fdc_trace_file = NULL;
 		g_fdc_trace_checked = false;
 		g_fdc_trace_lines = 0;
+		g_fdc_trace_max_lines = 200000;
+		g_fdc_trace_io_checked = false;
+		g_fdc_trace_io = false;
 	}
+	g_fdc_disable_unstable_checked = false;
+	g_fdc_disable_unstable = true;
+	g_fdc_const_exec_checked = false;
+	g_fdc_const_exec = true;
+	g_fdc_request_single_exec_checked = false;
+	g_fdc_request_single_exec = true;
+	g_fdc_tc_exec_checked = false;
+	g_fdc_tc_exec = true;
+	g_fdc_lost_usec_checked = false;
+	g_fdc_lost_usec = 15000;
 }
 
 void UPD765A::reset()
 {
 	shift_to_idle();
-//	CANCEL_EVENT();
-	phase_id = drq_id = lost_id = result7_id = -1;
-	seek_id[0] = seek_id[1] = seek_id[2] = seek_id[3] = -1;
-	seek_step_id[0] = seek_step_id[1] = seek_step_id[2] = seek_step_id[3] = -1;
-	seek_step_remain[0] = seek_step_remain[1] = seek_step_remain[2] = seek_step_remain[3] = 0;
-	head_unload_id[0] = head_unload_id[1] = head_unload_id[2] = head_unload_id[3] = -1;
+	if(phase_id != -1) {
+		cancel_event(this, phase_id);
+		phase_id = -1;
+	}
+	if(drq_id != -1) {
+		cancel_event(this, drq_id);
+		drq_id = -1;
+	}
+	if(lost_id != -1) {
+		cancel_event(this, lost_id);
+		lost_id = -1;
+	}
+	if(result7_id != -1) {
+		cancel_event(this, result7_id);
+		result7_id = -1;
+	}
+	for(int i = 0; i < 4; i++) {
+		if(seek_id[i] != -1) {
+			cancel_event(this, seek_id[i]);
+		}
+		if(seek_step_id[i] != -1) {
+			// Loop events are not guaranteed to be canceled by EVENT::reset().
+			cancel_event(this, seek_step_id[i]);
+		}
+		if(head_unload_id[i] != -1) {
+			cancel_event(this, head_unload_id[i]);
+		}
+		seek_id[i] = -1;
+		seek_step_id[i] = -1;
+		seek_step_remain[i] = 0;
+		head_unload_id[i] = -1;
+	}
 	head_load[0] = head_load[1] = head_load[2] = head_load[3] = false;
 	cur_track[0] = fdc[0].track;
 	cur_track[1] = fdc[1].track;
 	cur_track[2] = fdc[2].track;
 	cur_track[3] = fdc[3].track;
+	command = 0;
+	result = 0;
+	hdue = hdu;
+	id[0] = id[1] = id[2] = id[3] = 0;
+	eot = 0;
+	gpl = 0;
+	dtl = 0;
 	
 	set_irq(false);
 	set_drq(false);
@@ -406,10 +583,15 @@ uint32 UPD765A::read_io8(uint32 addr)
 			
 			switch(phase) {
 			case PHASE_RESULT:
+			{
+				int idx = (int)(bufptr - buffer);
 				data = *bufptr++;
 #ifdef _FDC_DEBUG_LOG
 				emu->out_debug_log("FDC: RESULT=%2x\n", data);
 #endif
+				if(fdc_trace_io_enabled()) {
+					fdc_trace("result_byte: cmd=%02x idx=%d data=%02x", command, idx, data);
+				}
 				if(--count) {
 					status |= S_RQM;
 				} else {
@@ -429,6 +611,7 @@ uint32 UPD765A::read_io8(uint32 addr)
 					shift_to_idle();
 				}
 				return data;
+			}
 				
 			case PHASE_READ:
 				data = *bufptr++;
@@ -491,7 +674,7 @@ void UPD765A::write_signal(int id, uint32 data, uint32 mask)
 	} else if(id == SIG_UPD765A_TC) {
 #ifdef SDL
 		// phase==PHASE_EXEC support (for Xanadu Scenario II)
-		if(phase == PHASE_READ || phase == PHASE_WRITE || phase == PHASE_SCAN || (phase == PHASE_RESULT && count == 7) || (phase == PHASE_EXEC)) {
+		if(phase == PHASE_READ || phase == PHASE_WRITE || phase == PHASE_SCAN || (phase == PHASE_RESULT && count == 7) || (fdc_tc_exec_enabled() && phase == PHASE_EXEC)) {
 #else
 		if(phase == PHASE_READ || phase == PHASE_WRITE || phase == PHASE_SCAN || (phase == PHASE_RESULT && count == 7)) {
 #endif // SDL
@@ -540,7 +723,9 @@ uint32 UPD765A::read_signal(int ch)
 void UPD765A::event_callback(int event_id, int err)
 {
 #ifdef SDL
-	request_single_exec();
+	if(fdc_request_single_exec_enabled()) {
+		request_single_exec();
+	}
 #endif // SDL
 	if(event_id == EVENT_PHASE) {
 		phase_id = -1;
@@ -645,16 +830,21 @@ void UPD765A::set_drq(bool val)
 		// EPSON QC-10 CP/M Plus
 		dma_data_lost = true;
 #else
-		if((command & 0x1f) != 0x0d) {
+			if((command & 0x1f) != 0x0d) {
 #ifdef SDL
-			// for customized event manager + 2HD disk
-			register_event(this, EVENT_LOST, 30000, false, &lost_id);
+				// for customized event manager + 2HD disk
+				int usec = fdc_lost_event_usec();
+				if(usec > 0) {
+					register_event(this, EVENT_LOST, usec, false, &lost_id);
+				} else {
+					register_event(this, EVENT_LOST, disk[hdu & DRIVE_MASK]->get_usec_per_bytes(1), false, &lost_id);
+				}
 #else
-			register_event(this, EVENT_LOST, disk[hdu & DRIVE_MASK]->get_usec_per_bytes(1), false, &lost_id);
+				register_event(this, EVENT_LOST, disk[hdu & DRIVE_MASK]->get_usec_per_bytes(1), false, &lost_id);
 #endif // SDL
-		} else {
-			// FIXME: write id
-			register_event(this, EVENT_LOST, 30000, false, &lost_id);
+			} else {
+				// FIXME: write id
+				register_event(this, EVENT_LOST, 30000, false, &lost_id);
 		}
 #endif
 	}
@@ -692,7 +882,7 @@ void UPD765A::set_hdu(uint8 val)
 
 void UPD765A::process_cmd(int cmd)
 {
-	fdc_trace("cmd=%02x phase=%d hdu=%d C=%02x H=%02x R=%02x N=%02x", cmd & 0x1f, phase, hdu & DRIVE_MASK, id[0], id[1], id[2], id[3]);
+	fdc_trace("cmd=%02x op=%02x phase=%d hdu=%d C=%02x H=%02x R=%02x N=%02x", command, cmd & 0x1f, phase, hdu & DRIVE_MASK, id[0], id[1], id[2], id[3]);
 	switch(cmd & 0x1f) {
 	case 0x02:
 		cmd_read_diagnostic();
@@ -746,6 +936,7 @@ void UPD765A::cmd_sence_devstat()
 	case PHASE_CMD:
 		set_hdu(buffer[0]);
 		buffer[0] = get_devstat(buffer[0] & DRIVE_MASK);
+		fdc_trace("sense_devstat: drv=%d st3=%02x cur=%d tgt=%d", buffer[0] & DRIVE_MASK, buffer[0], cur_track[buffer[0] & DRIVE_MASK], fdc[buffer[0] & DRIVE_MASK].track);
 		shift_to_result(1);
 		break;
 	}
@@ -758,6 +949,7 @@ void UPD765A::cmd_sence_intstat()
 			buffer[0] = (uint8)fdc[i].result;
 			buffer[1] = (uint8)fdc[i].track;
 			fdc[i].result = 0;
+			fdc_trace("sense_intstat: drv=%d st0=%02x pcn=%02x", i, buffer[0], buffer[1]);
 			shift_to_result(2);
 			return;
 		}
@@ -768,6 +960,7 @@ void UPD765A::cmd_sence_intstat()
 #else
 	buffer[0] = (uint8)ST0_IC;
 #endif
+	fdc_trace("sense_intstat: no_pending st0=%02x", buffer[0]);
 	shift_to_result(1);
 //	status &= ~S_CB;
 }
@@ -777,10 +970,14 @@ uint8 UPD765A::get_devstat(int drv)
 	if(drv >= MAX_DRIVE) {
 		return ST3_FT | drv;
 	}
+	// Keep ST3 track-side bit based on commanded track like common_source_project.
+	// Using cur_track here can introduce host-timing dependent behavior while seek
+	// step events are in flight.
+	int track_for_st3 = fdc[drv].track;
 	return drv |
-	       ((cur_track[drv] & 1) ? ST3_HD : 0) |
+	       ((track_for_st3 & 1) ? ST3_HD : 0) |
 	       ST3_TS |
-	       (cur_track[drv] ? 0 : ST3_T0) |
+	       (track_for_st3 ? 0 : ST3_T0) |
 	       ((force_ready || disk[drv]->inserted) ? ST3_RY : 0) |
 	       (disk[drv]->write_protected ? ST3_WP : 0);
 }
@@ -820,16 +1017,24 @@ void UPD765A::seek(int drv, int trk)
 	if(steptime <= 0) {
 		steptime = 1;
 	}
+	int seek_scale = fdc_seek_scale();
+	int steptime_usec = steptime * seek_scale;
+	if(steptime_usec <= 0) {
+		steptime_usec = 1;
+	}
 	
 	if(drv >= MAX_DRIVE) {
 		// invalid drive number
 		fdc[drv].result = (drv & DRIVE_MASK) | ST0_SE | ST0_NR | ST0_AT;
 		set_irq(true);
 	} else {
-		// get distance
-		int distance = abs(trk - cur_track[drv]);
-		int seektime = (distance == 0) ? 120 : steptime * distance + 500; // usec
-		fdc_trace("seek: drv=%d from=%d to=%d dist=%d steptime=%d seektime=%d", drv, cur_track[drv], trk, distance, steptime, seektime);
+		// Match common_source_project: SEEK timing is based on previous
+		// commanded track, not current stepped track.
+		int prev_track = fdc[drv].track;
+		int distance = abs(trk - prev_track);
+		int seektime = (distance == 0) ? 120 : steptime_usec * distance + 500; // usec
+		fdc_trace("seek: drv=%d from=%d to=%d dist=%d steptime=%d steptime_us=%d scale=%d seektime=%d", drv, prev_track, trk, distance, steptime, steptime_usec, seek_scale, seektime);
+		cur_track[drv] = prev_track;
 		fdc[drv].track = trk;
 #ifdef UPD765A_DONT_WAIT_SEEK
 		if(distance > 0 && d_noise_seek != NULL) {
@@ -853,7 +1058,7 @@ void UPD765A::seek(int drv, int trk)
 #endif // SDL
 		if(distance > 0) {
 			seek_step_remain[drv] = distance;
-			register_event(this, EVENT_SEEK_STEP + drv, steptime, true, &seek_step_id[drv]);
+			register_event(this, EVENT_SEEK_STEP + drv, steptime_usec, true, &seek_step_id[drv]);
 		} else {
 			cur_track[drv] = fdc[drv].track;
 		}
@@ -1216,10 +1421,13 @@ uint32 UPD765A::read_sector()
 			fdc_trace("read_sector: zero size drv=%d trk=%d side=%d idx=%d", drv, trk, side, i);
 			continue;
 		}
+		if(disk[drv]->invalid_format) {
+			fdc_trace("read_sector: invalid_format drv=%d trk=%d side=%d idx=%d unstable=%d", drv, trk, side, i, (disk[drv]->unstable != NULL) ? 1 : 0);
+		}
 		// sector number is matched
 		if(disk[drv]->invalid_format) {
 			for(int j = 0; j < disk[drv]->sector_size.sd; j++) {
-				uint8 mask = disk[drv]->unstable ? disk[drv]->unstable[j] : 0;
+				uint8 mask = (disk[drv]->unstable != NULL && !fdc_disable_unstable_mask()) ? disk[drv]->unstable[j] : 0;
 				buffer[j] = (disk[drv]->sector[j] & ~mask) | (rand() & mask);
 			}
 			memset(buffer + disk[drv]->sector_size.sd, disk[drv]->drive_mfm ? 0x4e : 0xff, sizeof(buffer) - disk[drv]->sector_size.sd);
@@ -1237,7 +1445,16 @@ uint32 UPD765A::read_sector()
 			fdc_trace("read_sector: deleted mark drv=%d trk=%d side=%d idx=%d C=%02x H=%02x R=%02x N=%02x", drv, trk, side, i, disk[drv]->id[0], disk[drv]->id[1], disk[drv]->id[2], disk[drv]->id[3]);
 			return ST2_CM;
 		}
-		fdc_trace("read_sector: ok drv=%d trk=%d side=%d idx=%d C=%02x H=%02x R=%02x N=%02x len=%d", drv, trk, side, i, disk[drv]->id[0], disk[drv]->id[1], disk[drv]->id[2], disk[drv]->id[3], disk[drv]->sector_size.sd);
+		int transfer_len = (id[3] != 0) ? (0x80 << min((int)id[3], 7)) : min((int)dtl, 0x80);
+		transfer_len = min(transfer_len, disk[drv]->sector_size.sd);
+		uint32 data_hash = fdc_hash_bytes(buffer, transfer_len);
+		uint8 b0 = (transfer_len > 0) ? buffer[0] : 0;
+		uint8 b1 = (transfer_len > 1) ? buffer[1] : 0;
+		uint8 b2 = (transfer_len > 2) ? buffer[2] : 0;
+		uint8 b3 = (transfer_len > 3) ? buffer[3] : 0;
+		fdc_trace("read_sector: ok drv=%d trk=%d side=%d idx=%d C=%02x H=%02x R=%02x N=%02x seclen=%d xfer=%d hash=%08x b0=%02x b1=%02x b2=%02x b3=%02x",
+		          drv, trk, side, i, disk[drv]->id[0], disk[drv]->id[1], disk[drv]->id[2], disk[drv]->id[3],
+		          disk[drv]->sector_size.sd, transfer_len, data_hash, b0, b1, b2, b3);
 		return 0;
 	}
 	#ifdef _FDC_DEBUG_LOG
@@ -1645,6 +1862,9 @@ void UPD765A::shift_to_result(int length)
 	status = S_RQM | S_CB | S_DIO;
 	bufptr = buffer;
 	count = length;
+	if(fdc_trace_io_enabled()) {
+		fdc_trace("shift_result: cmd=%02x len=%d status=%02x", command, length, status);
+	}
 }
 
 void UPD765A::shift_to_result7()
@@ -1675,6 +1895,7 @@ void UPD765A::shift_to_result7_event()
 	buffer[4] = id[1];
 	buffer[5] = id[2];
 	buffer[6] = id[3];
+	fdc_trace("result7: cmd=%02x st0=%02x st1=%02x st2=%02x C=%02x H=%02x R=%02x N=%02x", command, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], buffer[5], buffer[6]);
 	set_irq(true);
 	shift_to_result(7);
 }
@@ -1725,6 +1946,12 @@ double UPD765A::get_usec_to_exec_phase()
 	int drv = hdu & DRIVE_MASK;
 	int trk = fdc[drv].track;
 	int side = (hdu >> 2) & 1;
+
+	// Optional timing stabilization for troublesome titles:
+	// keep EXEC transition delay deterministic and independent of rotational position.
+	if(fdc_const_exec_timing()) {
+		return 100;
+	}
 	
 	// XXX: this image may have incorrect skew, so use constant period.
 	if(!disk[drv]->correct_timing()) {


### PR DESCRIPTION
## 概要
- Wizardryの4MHz環境で起動が不安定になる問題に対し、FDC周辺のタイミングと起動プロファイルを整理しました。
- 再現実験で有効だった条件をコア側既定値とデバッグ設定に反映しています。

## 主な変更
- Source/ePC-8801MA/vm/upd765a.cpp
  - FDCの実行フェーズ固定タイミングを既定有効化
  - LOSTイベント既定値を4MHz向けに調整
  - unstableマスク無効化を既定有効化
  - 検証用環境変数トグル（TC/LOST/single-exec）を整理
- Source/ePC-8801MA/vm/event.cpp
  - single_exec周辺の挙動整理
- Source/ePC-8801MA/vm/disk.cpp / Source/ePC-8801MA/vm/disk.h
  - トラック/セクタ処理の互換性調整
- .vscode/launch.json
  - 検証用途を絞った起動プロファイルへ整理

## 確認
- macOSビルド成功（cmake --build build -j8）
- 4MHz + Wizardry安定化プロファイルで正常起動を確認

## 備考
- 8MHz向けの最適化は別ブランチで継続します。
