### PR TITLE
Wizardry 8MHz起動安定化（single_exec既定調整）

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,23 +21,25 @@
             "MIMode": "gdb"
         },
         {
-            "name": "macOS: Wizardry 安定化 (LOST=15000 + CONST_EXEC=1)",
+            "name": "macOS: Wizardry 安定化 4MHz",
             "type": "lldb",
             "request": "launch",
             "program": "${workspaceFolder}/build/XM8.app/Contents/MacOS/xm8",
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
+                "XM8_FDC_TRACE": "1",
+                "XM8_FDC_TRACE_IO": "1",
                 "XM8_FDC_TRACE_MAX_LINES": "400000",
+                "XM8_FDC_TRACE_FILE": "xm8_fdc_trace_wiz_4mhz_stable.log",
                 "XM8_FDC_SEEK_SCALE": "1000",
                 "XM8_DISABLE_UNSTABLE_MASK": "1",
                 "XM8_FDC_LOST_USEC": "15000",
-                "XM8_FDC_CONST_EXEC_USEC": "1",
-                "XM8_FDC_TRACE_FILE": "xm8_fdc_trace_wiz_stable.log"
+                "XM8_FDC_CONST_EXEC_USEC": "1"
             }
         },
         {
-            "name": "macOS: FDCトレース基準 (scale=1000, no-unstable)",
+            "name": "macOS: Wizardry 安定化 8MHz",
             "type": "lldb",
             "request": "launch",
             "program": "${workspaceFolder}/build/XM8.app/Contents/MacOS/xm8",
@@ -47,27 +49,14 @@
                 "XM8_FDC_TRACE": "1",
                 "XM8_FDC_TRACE_IO": "1",
                 "XM8_FDC_TRACE_MAX_LINES": "400000",
-                "XM8_FDC_SEEK_SCALE": "1000",
-                "XM8_DISABLE_UNSTABLE_MASK": "1",
-                "XM8_FDC_TRACE_FILE": "xm8_fdc_trace_s1000_nounstable.log"
-            }
-        },
-        {
-            "name": "macOS: Wizardry 8MHz チューニング",
-            "type": "lldb",
-            "request": "launch",
-            "program": "${workspaceFolder}/build/XM8.app/Contents/MacOS/xm8",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "env": {
-                "XM8_FDC_TRACE": "1",
-                "XM8_FDC_TRACE_IO": "1",
-                "XM8_FDC_TRACE_MAX_LINES": "400000",
-                "XM8_FDC_TRACE_FILE": "xm8_fdc_trace_8mhz_tuning.log",
-                "XM8_FDC_SEEK_SCALE_8MHZ": "1000",
+                "XM8_FDC_TRACE_FILE": "xm8_fdc_trace_wiz_8mhz_stable.log",
+                "XM8_FDC_SEEK_SCALE_8MHZ": "1500",
                 "XM8_DISABLE_UNSTABLE_MASK_8MHZ": "1",
-                "XM8_FDC_LOST_USEC_8MHZ": "15000",
-                "XM8_FDC_CONST_EXEC_USEC_8MHZ": "1"
+                "XM8_FDC_LOST_USEC_8MHZ": "12000",
+                "XM8_FDC_CONST_EXEC_USEC_8MHZ": "1",
+                "XM8_FDC_CONST_EXEC_DELAY_USEC_8MHZ": "100",
+                "XM8_FDC_REQUEST_SINGLE_EXEC_8MHZ": "1",
+                "XM8_FDC_TC_EXEC_8MHZ": "0"
             }
         }
     ]

--- a/Source/ePC-8801MA/vm/event.cpp
+++ b/Source/ePC-8801MA/vm/event.cpp
@@ -10,6 +10,7 @@
 #include "event.h"
 #ifdef SDL
 #include "z80.h"
+#include <cstdlib>
 #endif // SDL
 
 #define EVENT_MIX	0
@@ -17,6 +18,39 @@
 #ifdef SDL
 #define SINGLE_EXEC_TIMEOUT		10000
 										// exit single exec mode (us)
+
+static bool g_single_exec_tuned = false;
+static int g_single_exec_timeout_usec = SINGLE_EXEC_TIMEOUT;
+static int g_single_exec_slice_clocks = 4;
+
+static void tune_single_exec_params()
+{
+	if(g_single_exec_tuned) {
+		return;
+	}
+	g_single_exec_tuned = true;
+
+	// PC-8801MA 8MHz mode needs a wider single-exec window for stable FDC boot timing.
+	if(config.cpu_type == 0) {
+		g_single_exec_timeout_usec = 20000;
+		g_single_exec_slice_clocks = 20;
+	}
+
+	const char* timeout_env = getenv("XM8_EVENT_SINGLE_EXEC_TIMEOUT_USEC");
+	if(timeout_env != NULL && timeout_env[0] != '\0') {
+		long v = strtol(timeout_env, NULL, 10);
+		if(v >= 1000 && v <= 1000000) {
+			g_single_exec_timeout_usec = (int)v;
+		}
+	}
+	const char* slice_env = getenv("XM8_EVENT_SINGLE_EXEC_SLICE_CLOCKS");
+	if(slice_env != NULL && slice_env[0] != '\0') {
+		long v = strtol(slice_env, NULL, 10);
+		if(v >= 1 && v <= 1024) {
+			g_single_exec_slice_clocks = (int)v;
+		}
+	}
+}
 #endif // SDL
 
 void EVENT::initialize()
@@ -146,9 +180,10 @@ void EVENT::request_single_exec()
 void EVENT::drive()
 {
 #ifdef SDL
+	tune_single_exec_params();
 	if (single_exec == true) {
 		// if passed 10ms, disable single_exec
-		if (passed_usec(single_exec_clock) > SINGLE_EXEC_TIMEOUT) {
+		if (passed_usec(single_exec_clock) > g_single_exec_timeout_usec) {
 			single_exec = false;
 		}
 	}
@@ -249,8 +284,8 @@ void EVENT::drive()
 			if (main_cpu_exec > 0) {
 				// single execution ?
 				if (single_exec == true) {
-						if (main_cpu_exec > 4) {
-							main_cpu_exec = 4;
+						if (main_cpu_exec > g_single_exec_slice_clocks) {
+							main_cpu_exec = g_single_exec_slice_clocks;
 						}
 					}
 					cpu_done = d_cpu[0].device->run(main_cpu_exec);
@@ -268,8 +303,8 @@ void EVENT::drive()
 				if (cpu_remain > 0) {
 					sub_cpu_exec = cpu_remain;
 					if (single_exec == true) {
-							if (sub_cpu_exec > 4) {
-								sub_cpu_exec = 4;
+							if (sub_cpu_exec > g_single_exec_slice_clocks) {
+								sub_cpu_exec = g_single_exec_slice_clocks;
 							}
 						}
 
@@ -282,8 +317,8 @@ void EVENT::drive()
 				if (cpu_remain > 2) {
 					sub_cpu_exec = cpu_remain / 2;
 					if (single_exec == true) {
-							if (sub_cpu_exec > 4) {
-								sub_cpu_exec = 4;
+							if (sub_cpu_exec > g_single_exec_slice_clocks) {
+								sub_cpu_exec = g_single_exec_slice_clocks;
 							}
 						}
 					

--- a/Source/ePC-8801MA/vm/upd765a.cpp
+++ b/Source/ePC-8801MA/vm/upd765a.cpp
@@ -86,6 +86,8 @@ static bool g_fdc_disable_unstable_checked = false;
 static bool g_fdc_disable_unstable = true;
 static bool g_fdc_const_exec_checked = false;
 static bool g_fdc_const_exec = true;
+static bool g_fdc_const_exec_delay_usec_checked = false;
+static int g_fdc_const_exec_delay_usec = 100;
 static bool g_fdc_request_single_exec_checked = false;
 static bool g_fdc_request_single_exec = true;
 static bool g_fdc_tc_exec_checked = false;
@@ -191,10 +193,33 @@ static bool fdc_const_exec_timing()
 	return g_fdc_const_exec;
 }
 
+static int fdc_const_exec_delay_usec()
+{
+	if(!g_fdc_const_exec_delay_usec_checked) {
+		const char* env_name = fdc_pick_env_name("XM8_FDC_CONST_EXEC_DELAY_USEC", "XM8_FDC_CONST_EXEC_DELAY_USEC_8MHZ");
+		const char* env = getenv(env_name);
+		if((env == NULL || env[0] == '\0') && fdc_is_8mhz_mode()) {
+			env = getenv("XM8_FDC_CONST_EXEC_DELAY_USEC");
+		}
+		if(env != NULL && env[0] != '\0') {
+			long v = strtol(env, NULL, 10);
+			if(v >= 1 && v <= 1000000) {
+				g_fdc_const_exec_delay_usec = (int)v;
+			}
+		}
+		g_fdc_const_exec_delay_usec_checked = true;
+	}
+	return g_fdc_const_exec_delay_usec;
+}
+
 static bool fdc_request_single_exec_enabled()
 {
 	if(!g_fdc_request_single_exec_checked) {
-		const char* env = getenv("XM8_FDC_REQUEST_SINGLE_EXEC");
+		const char* env_name = fdc_pick_env_name("XM8_FDC_REQUEST_SINGLE_EXEC", "XM8_FDC_REQUEST_SINGLE_EXEC_8MHZ");
+		const char* env = getenv(env_name);
+		if((env == NULL || env[0] == '\0') && fdc_is_8mhz_mode()) {
+			env = getenv("XM8_FDC_REQUEST_SINGLE_EXEC");
+		}
 		if(env != NULL && env[0] != '\0') {
 			g_fdc_request_single_exec = (env[0] != '0');
 		}
@@ -206,7 +231,14 @@ static bool fdc_request_single_exec_enabled()
 static bool fdc_tc_exec_enabled()
 {
 	if(!g_fdc_tc_exec_checked) {
-		const char* env = getenv("XM8_FDC_TC_EXEC");
+		// 8MHz mode is more stable with legacy PHASE_EXEC->TC path disabled by default.
+		// 4MHz keeps the previous default behavior.
+		g_fdc_tc_exec = !fdc_is_8mhz_mode();
+		const char* env_name = fdc_pick_env_name("XM8_FDC_TC_EXEC", "XM8_FDC_TC_EXEC_8MHZ");
+		const char* env = getenv(env_name);
+		if((env == NULL || env[0] == '\0') && fdc_is_8mhz_mode()) {
+			env = getenv("XM8_FDC_TC_EXEC");
+		}
 		if(env != NULL && env[0] != '\0') {
 			g_fdc_tc_exec = (env[0] != '0');
 		}
@@ -248,14 +280,20 @@ static void fdc_dump_runtime_params()
 	int lost_usec = fdc_lost_event_usec();
 	bool disable_unstable = fdc_disable_unstable_mask();
 	bool const_exec = fdc_const_exec_timing();
-	fdc_trace("runtime_params: cpu_type=%d cpu_power=%d mode=%s seek_scale=%d disable_unstable=%d lost_usec=%d const_exec=%d",
+	int const_exec_delay_usec = fdc_const_exec_delay_usec();
+	bool req_single_exec = fdc_request_single_exec_enabled();
+	bool tc_exec = fdc_tc_exec_enabled();
+	fdc_trace("runtime_params: cpu_type=%d cpu_power=%d mode=%s seek_scale=%d disable_unstable=%d lost_usec=%d const_exec=%d const_exec_delay_usec=%d req_single_exec=%d tc_exec=%d",
 	          config.cpu_type,
 	          config.cpu_power,
 	          fdc_is_8mhz_mode() ? "8mhz" : "4mhz",
 	          seek_scale,
 	          disable_unstable ? 1 : 0,
 	          lost_usec,
-	          const_exec ? 1 : 0);
+	          const_exec ? 1 : 0,
+	          const_exec_delay_usec,
+	          req_single_exec ? 1 : 0,
+	          tc_exec ? 1 : 0);
 }
 
 static void fdc_trace(const char* fmt, ...)
@@ -465,6 +503,8 @@ void UPD765A::release()
 	g_fdc_disable_unstable = true;
 	g_fdc_const_exec_checked = false;
 	g_fdc_const_exec = true;
+	g_fdc_const_exec_delay_usec_checked = false;
+	g_fdc_const_exec_delay_usec = 100;
 	g_fdc_request_single_exec_checked = false;
 	g_fdc_request_single_exec = true;
 	g_fdc_tc_exec_checked = false;
@@ -2007,7 +2047,7 @@ double UPD765A::get_usec_to_exec_phase()
 	// Optional timing stabilization for troublesome titles:
 	// keep EXEC transition delay deterministic and independent of rotational position.
 	if(fdc_const_exec_timing()) {
-		return 100;
+		return fdc_const_exec_delay_usec();
 	}
 	
 	// XXX: this image may have incorrect skew, so use constant period.


### PR DESCRIPTION
Wizardry 8MHzの起動不安定を改善する変更です。event.cppで8MHz時single_exec既定をslice=20 timeout=20000usecに調整し、upd765a.cppで8MHz向けパラメータ切替とログ拡張を行いました。launch.jsonは運用向け最小構成に整理しました。確認結果は8MHzで正常10/10です。