### PR TITLE
Exclude Brewfile from Linguist language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Builder/macOS/Brewfile linguist-detectable=false


### PR DESCRIPTION
## Summary
- `Builder/macOS/Brewfile` (1 line) was being classified as Ruby by GitHub Linguist (12 bytes), which caused the GitHub-managed CodeQL setup to incorrectly try to analyze the repository as a Ruby project and fail.
- Add a `.gitattributes` entry to exclude the Brewfile from Linguist detection so the repository is no longer flagged as containing Ruby.

## Test plan
- [ ] After merge, confirm `Ruby` no longer appears in `gh api repos/bubio/xm8mac/languages`
- [ ] Confirm CodeQL default setup no longer attempts a Ruby analysis (re-run / re-enable default setup if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)